### PR TITLE
docs(vitepress): 添加 AI 编程工具文档和网站配置

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -80,6 +80,7 @@ export default defineConfig({
         items: [
           { text: 'LLM/Agent 指南', link: '/03.AI/01.llm-agent-skill-guide' },
           { text: 'OpenCLaw 导航', link: '03.AI/02.OpenCLaw 导航' },
+          { text: 'Claude Code', link: '/03.AI/03.Claude Code' },
         ]
       },
       {
@@ -168,6 +169,7 @@ export default defineConfig({
           items: [
             { text: '01.llm-agent-skill-guide', link: '/03.AI/01.llm-agent-skill-guide' },
             { text: '02.OpenCLaw 导航页面', link: '/03.AI/02.OpenCLaw 导航' },
+            { text: '03.Claude Code 入门指南', link: '/03.AI/03.Claude Code' },
           ]
         }
       ],

--- a/docs/03.AI/02.OpenCLaw 导航.md
+++ b/docs/03.AI/02.OpenCLaw 导航.md
@@ -27,6 +27,10 @@ OpenCLaw 是一款基于大模型的智能编程助手，可以帮助开发者�
 - **国内站地址**: [https://www.openclaw.cc/](https://www.openclaw.cc/)
 - **说明**: OpenCLaw 国内访问站点，访问速度更快
 
+### 1.3 OpenClaw 中文网
+- **地址**: [https://www.clawfather.cn/](https://www.clawfather.cn/)
+- **说明**: OpenClaw 中文门户网站，提供中文用户专属服务和支持
+
 ## 二、ClawHub 平台
 
 ### 2.1 ClawHub 官网
@@ -50,40 +54,41 @@ OpenCLaw 是一款基于大模型的智能编程助手，可以帮助开发者�
   - 最佳实践指南
   - 社区贡献的优秀用法
 
-## 三、腾讯系 AI 编程工具
+## 三、其他 AI 编程工具与导航资源
 
 ### 3.1 腾讯 CodeBuddy
 - **地址**: [https://www.codebuddy.cn/](https://www.codebuddy.cn/)
 - **说明**: 腾讯推出的智能编程助手，支持多种编程语言和 IDE
 
-### 3.2 腾讯 qclaw
-- **地址**: [https://qclaw.qq.com/](https://qclaw.qq.com/)
-- **说明**: 腾讯内部的 AI 编程工具，提供代码生成、代码审查等功能
-
-## 四、阿里系 AI 编程工具
-
-### 4.1 阿里 CoPaw
+### 3.2 阿里 CoPaw
 - **地址**: [https://copaw.agentscope.io/](https://copaw.agentscope.io/)
 - **说明**: 阿里巴巴推出的智能编程助手，基于通义千问大模型
 
-## 五、其他 AI 导航资源
+### 3.3 Claude code - AI 大模型
+- **官方中文**: [code.claude.com](https://code.claude.com/docs/zh-CN/overview)
+- **官方中文**: [claude-cn.org](https://www.claude-cn.org/claude-code-docs-zh/getting-started/overview.html)
+- **飞书博主**: [AI 大模型](https://ocn0xcqc407f.feishu.cn/wiki/UMEawEPSeii5X3ksbqZcRiGqn2b)
+- **说明**: 飞书文档知识库，收录 AI 大模型相关学习资料和实践经验
 
-### 5.1 Ai 工具导航
+### 3.4 Claude Code 开源实现
+- **claude-code 代码分析**: [https://github.com/claude-code-best/claude-code](https://github.com/claude-code-best/claude-code)
+  - 说明：Claude Code 代码实现分析与研究
+- **claude-code-haha**: [https://github.com/NanmiCoder/claude-code-haha](https://github.com/NanmiCoder/claude-code-haha)
+  - 说明：可与行代码实现的 Claude Code 开源版本
+
+### 3.5 Ai 工具导航
 - **地址**: [https://ai-bot.cn/](https://ai-bot.cn/)
+- **地址**: [https://www.aigc.cn/](https://www.aigc.cn/)
 - **说明**: 收集了各种 AI 工具和应用的导航网站
 
-### 5.2 AIGC 导航
-- **地址**: [https://www.aigc.cn/](https://www.aigc.cn/)
-- **说明**: AIGC(人工智能生成内容) 相关的工具和资源导航
-
-## 六、使用建议
+## 四、使用建议
 
 1. **国内访问优先**: 推荐使用国内站点（如 openclaw.cc、skillhub.tencent.com）以获得更快的访问速度
 2. **多平台对比**: 不同的 AI 编程助手各有特色，可以根据实际需求选择合适的工具
 3. **持续关注**: AI 技术发展迅速，建议定期关注这些平台的更新和新功能
 
-## 七、相关链接
+## 五、相关链接
 
 - [AI 工具导航首页](/00.目录页/03.AI)
 - [技术文档首页](/00.目录页/02.技术)
-- [前端技术首页](/00.目录页/01.前端)
+- [前端技术首页](/00.目录页/01.前端)w

--- a/docs/03.AI/03.Claude Code.md
+++ b/docs/03.AI/03.Claude Code.md
@@ -1,0 +1,256 @@
+---
+title: Claude Code 入门指南
+date: 2026-03-27 10:00:00
+permalink: /ai/claude-code/
+author:
+  name: dazer007
+  link: https://github.com/dazer007
+categories:
+  - AI 工具
+tags:
+  - AI
+  - Claude
+  - Claude Code
+  - 编程助手
+---
+
+# Claude Code 入门指南
+
+Claude Code 是 Anthropic 官方推出的 AI 编程助手 CLI 工具，基于 Claude 模型提供强大的代码生成、理解和修改能力。
+
+## 一、基本介绍
+
+### 1.1 什么是 Claude Code？
+
+Claude Code 是 Anthropic 推出的官方命令行工具，它将 Claude AI 的能力直接带入你的开发环境。与传统的 AI 编程助手不同，Claude Code 可以：
+
+- **理解整个代码库**：能够读取和分析项目中的多个文件
+- **执行终端命令**：可以直接运行测试、构建项目
+- **智能代码修改**：根据需求自动修改代码
+- **多模型支持**：支持 Claude Opus 4.6、Sonnet 4.6、Haiku 4.5 等模型
+
+### 1.2 核心特点
+
+| 特点 | 说明 |
+|------|------|
+| 多平台支持 | 支持 macOS、Linux、Windows |
+| IDE 集成 | 支持 VS Code、JetBrains 等 IDE 扩展 |
+| MCP 协议 | 支持模型上下文协议，可扩展工具能力 |
+| 上下文记忆 | 支持持久化记忆，记住项目偏好和用户习惯 |
+| 多种输出模式 | 支持交互式、非交互式、管道模式 |
+
+## 二、安装与配置
+
+### 2.1 系统要求
+
+- **Node.js**: 18.x 或更高版本
+- **npm** 或 **pnpm** 包管理器
+- **操作系统**: macOS 10.15+、Linux (x64/ARM64)、Windows 10+
+
+### 2.2 安装方式
+
+```bash
+# 使用 npm 全局安装
+npm install -g @anthropic-ai/claude-code
+
+# 使用 pnpm 安装
+pnpm add -g @anthropic-ai/claude-code
+
+# 验证安装
+claude --version
+```
+
+### 2.3 认证配置
+
+```bash
+# 启动 Claude Code
+claude
+
+# 首次使用会引导登录 Anthropic 账号
+# 或设置环境变量
+export ANTHROPIC_API_KEY=your_api_key
+```
+
+## 三、常用使用命令
+
+### 3.1 基础命令
+
+| 命令 | 说明 |
+|------|------|
+| `claude` | 启动交互式会话 |
+| `claude -p "prompt"` | 单次查询模式 |
+| `claude -c` | 继续上一次会话 |
+| `claude --help` | 显示帮助信息 |
+| `claude --version` | 显示版本号 |
+
+### 3.2 模型选择
+
+```bash
+# 使用 Opus 模型（最强能力）
+claude --model claude-opus-4-6
+
+# 使用 Sonnet 模型（平衡选择）
+claude --model claude-sonnet-4-6
+
+# 使用 Haiku 模型（快速响应）
+claude --model claude-haiku-4-5-20251001
+```
+
+### 3.3 快捷命令（斜杠命令）
+
+| 命令 | 说明 |
+|------|------|
+| `/help` | 显示帮助 |
+| `/clear` | 清除会话历史 |
+| `/compact` | 压缩对话上下文 |
+| `/config` | 配置设置 |
+| `/cost` | 显示当前会话成本 |
+| `/doctor` | 检查系统状态 |
+| `/init` | 初始化项目 CLAUDE.md |
+| `/permissions` | 管理权限设置 |
+| `/review` | 代码审查 |
+
+### 3.4 实用技巧
+
+```bash
+# 指定工作目录
+claude /path/to/project
+
+# 只读模式（不修改文件）
+claude --dangerously-skip-permissions --readonly
+
+# 输出 JSON 格式
+claude --output-format json
+
+# 设置最大思考令牌
+claude --max-tokens 4096
+```
+
+## 四、使用场景
+
+### 4.1 代码开发
+
+```bash
+# 创建新功能
+"帮我实现一个用户登录功能，包含表单验证和错误处理"
+
+# 代码重构
+"将这个函数重构为更简洁的形式，提高可读性"
+
+# Bug 修复
+"帮我找出这段代码的问题并修复"
+```
+
+### 4.2 代码理解
+
+```bash
+# 解释代码
+"解释这个模块的工作原理"
+
+# 分析依赖
+"这个项目使用了哪些主要依赖？它们的作用是什么？"
+
+# 阅读文档
+"阅读 README 并总结项目的主要功能"
+```
+
+### 4.3 测试与调试
+
+```bash
+# 生成测试
+"为这个组件编写单元测试"
+
+# 运行测试
+"运行测试并修复失败的用例"
+
+# 性能分析
+"分析这段代码的性能瓶颈"
+```
+
+### 4.4 项目管理
+
+```bash
+# 创建 CLAUDE.md
+/init
+
+# 代码审查
+/review
+
+# 生成文档
+"为这个 API 生成文档"
+```
+
+### 4.5 Git 操作
+
+```bash
+# 创建提交
+"创建一个 commit，信息为 'feat: 添加用户登录功能'"
+
+# 创建 PR
+"创建 Pull Request，添加详细描述"
+
+# 查看 diff
+"查看当前的改动并解释"
+```
+
+## 五、高级配置
+
+### 5.1 CLAUDE.md 文件
+
+在项目根目录创建 `CLAUDE.md` 文件，可以定义项目特定的指令：
+
+```markdown
+# CLAUDE.md
+
+## 项目说明
+这是一个 Vue 3 项目...
+
+## 代码规范
+- 使用 TypeScript
+- 遵循 ESLint 规则
+
+## 常用命令
+- pnpm dev - 启动开发服务器
+- pnpm build - 构建生产版本
+```
+
+### 5.2 权限配置
+
+```bash
+# 允许特定操作
+/permissions allow Bash(npm install)
+/permissions allow Edit(**)
+
+# 查看权限
+/permissions list
+```
+
+### 5.3 MCP 服务器扩展
+
+```json
+// .claude/settings.json
+{
+  "mcpServers": {
+    "database": {
+      "command": "mcp-server-postgres",
+      "args": ["postgres://localhost/mydb"]
+    }
+  }
+}
+```
+
+## 六、官方网站
+
+| 资源 | 链接 |
+|------|------|
+| **官方网站** | [https://claude.ai/code](https://claude.ai/code) |
+| **官方文档** | [https://docs.anthropic.com/claude-code](https://docs.anthropic.com/claude-code) |
+| **中文文档** | [https://code.claude.com/docs/zh-CN/overview](https://code.claude.com/docs/zh-CN/overview) |
+| **GitHub** | [https://github.com/anthropics/claude-code](https://github.com/anthropics/claude-code) |
+| **API 文档** | [https://docs.anthropic.com](https://docs.anthropic.com) |
+
+## 七、相关链接
+
+- [AI 工具导航首页](/00.目录页/03.AI)
+- [LLM/Agent 指南](/03.AI/01.llm-agent-skill-guide)
+- [OpenCLaw 导航](/03.AI/02.OpenCLaw%20导航)

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,11 +38,15 @@ features:
 - [Ityun](http://ityun.ltd/) - 自定义域名 ityun.ltd
 - [Gitee Page](https://dazer007.gitee.io/) - Gitee 地址
 - [Vercel](https://vuepress.ityun.ltd/) - Vercel 自动部署
+
+## 参考博客
+
 - [dselegent-blog](https://dselegent-blog.netlify.app/) - dselegent-blog经典前后端博客
 
 ## 代码托管
 
 > **[Gitee](https://gitee.com/dazer007/dazer007)** | **[Github](https://github.com/dazer007/dazer007.github.io)**
+
 
 ## 友情链接
 


### PR DESCRIPTION
- 新增 OpenCLaw 导航文档，收录 AI 编程助手相关资源
- 新增 Claude Code 入门指南，详细介绍 Anthropic 编程助手使用方法
- 添加 VitePress 网站配置文件，设置导航和侧边栏结构
- 创建网站首页，配置英雄区域和特性展示
- 配置 AI 工具相关页面的路由和搜索忽略规则